### PR TITLE
Fix openssl command to get digest

### DIFF
--- a/gpg.sh
+++ b/gpg.sh
@@ -72,7 +72,7 @@ sign() {
   fi
   chart=$1
   echo "Signing $chart"
-  shasum=$(openssl sha -sha256 $chart| awk '{ print $2 }')
+  shasum=$(openssl dgst -sha256 $chart| awk '{ print $2 }')
   chartyaml=$(tar -zxf $chart --exclude 'charts/' -O '*/Chart.yaml')
 c=$(cat << EOF
 $chartyaml
@@ -110,7 +110,7 @@ verify() {
 }
 
 shasum() {
-  openssl sha -sha256 "$1" | awk '{ print $2 }'
+  openssl dgst -sha256 "$1" | awk '{ print $2 }'
 }
 
 if [[ $# < 1 ]]; then


### PR DESCRIPTION
openssl now uses the command `openssl dgst` to generate digests.
This is a change since this plugin was created. Tested this change
on mac and ubuntu 18.04.